### PR TITLE
Refresh current branch on window gaining focus.

### DIFF
--- a/addons/branch/plugin.cfg
+++ b/addons/branch/plugin.cfg
@@ -3,5 +3,5 @@
 name="Branch"
 description="A gamejam countdown plugin for the editor."
 author="Konrad Koch"
-version="0.0.1"
+version="0.0.2"
 script="plugin.gd"

--- a/addons/branch/plugin.gd
+++ b/addons/branch/plugin.gd
@@ -21,6 +21,12 @@ func _exit_tree():
 			remove_control_from_container(EditorPlugin.CONTAINER_TOOLBAR, branch_button)
 		branch_button.queue_free() 
 
+
+func _notification(what):
+	if what == NOTIFICATION_WM_FOCUS_IN:
+		get_curent_branch()
+
+
 func get_curent_branch() -> void:
 	var output = []
 	OS.execute( 'git', ['rev-parse', "--abbrev-ref", 'HEAD'], true, output )


### PR DESCRIPTION
This refreshes the current branch when the editor window gains focus. 

I believe, although I don't know, that most people would use an external tool (PowerShell, Terminal, Graphical GUI) to switch between branches. On return from this external tool, the current branch will be refreshed, reducing the need to remember to click on the button.